### PR TITLE
fix: Disable logging to stdout

### DIFF
--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"slices"
@@ -113,6 +114,7 @@ func NewDryRunClient() *Client {
 }
 
 func NewClient(cfg *gosnowflake.Config) (*Client, error) {
+	log.SetOutput(io.Discard)
 	var err error
 	if cfg == nil {
 		log.Printf("[DEBUG] Searching for default config in credentials chain...\n")


### PR DESCRIPTION
This module spams our logs, see example in 
![image](https://github.com/user-attachments/assets/c45099ea-4ba4-4ebc-96bc-1a949471b4ea)

We can disable some logs via env variables
https://github.com/cloudquery/terraform-provider-snowflake/blob/409441da88587d7c3e51e932fe199b3eb394b03d/pkg/sdk/client.go#L128
but not others https://github.com/cloudquery/terraform-provider-snowflake/blob/409441da88587d7c3e51e932fe199b3eb394b03d/pkg/sdk/client.go#L179

Also the env variables are read during `init()` https://github.com/cloudquery/terraform-provider-snowflake/blob/409441da88587d7c3e51e932fe199b3eb394b03d/pkg/sdk/client.go#L23 which means we'd have to set them before starting the plugin's process